### PR TITLE
feat: add healthcheck endpoint to get upstream/client connections

### DIFF
--- a/src/amqproxy.cr
+++ b/src/amqproxy.cr
@@ -5,11 +5,13 @@ require "uri"
 
 listen_address = "::"
 listen_port = 5673
+healcheck_port = -1
 log_level = Logger::INFO
 p = OptionParser.parse! do |parser|
   parser.banner = "Usage: amqproxy [options] [amqp upstream url]"
   parser.on("-l ADDRESS", "--listen=ADDRESS", "Address to listen on (default is all)") { |p| listen_address = p }
   parser.on("-p PORT", "--port=PORT", "Port to listen on (default: 5673)") { |p| listen_port = p.to_i }
+  parser.on("-c PORT", "--healcheck-port=PORT", "Health Chcek Port to listen on") { |p| healcheck_port = p.to_i }
   parser.on("-d", "--debug", "Verbose logging") { |d| log_level = Logger::DEBUG }
   parser.on("-h", "--help", "Show this help") { abort parser.to_s }
   parser.invalid_option { |arg| abort "Invalid argument: #{arg}" }
@@ -37,5 +39,9 @@ shutdown = -> (s : Signal) do
 end
 Signal::INT.trap &shutdown
 Signal::TERM.trap &shutdown
+
+if healcheck_port > 0
+    server.healthcheck(listen_address, healcheck_port)
+end
 
 server.listen(listen_address, listen_port)

--- a/src/amqproxy/pool.cr
+++ b/src/amqproxy/pool.cr
@@ -6,6 +6,10 @@ module AMQProxy
       @size = 0
     end
 
+    def upstream
+      "#{@host}:#{@port}"
+    end
+
     def borrow(user : String, password : String, vhost : String, &block : (Upstream | Nil) -> _)
       q = @pools[[user, password, vhost].join] ||= Deque(Upstream).new
       u = q.shift do


### PR DESCRIPTION
I found that upstream connections will not be closed once connected, and the number will keep at the peak value of the number of concurrent client connections
We concern about the connections numbers and want to monitor it with datadog, so added a healthcheck endpoint

Because I pick up crystal lang from this project, please let me know if I did something wrong, Thanks!