### PR TITLE
fix: close upstream when pipe is broken

### DIFF
--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -84,6 +84,7 @@ module AMQProxy
     rescue ex : Errno | IO::EOFError
       @log.error "Error sending to upstream: #{ex.inspect}"
       @to_client.send nil
+      close
     end
 
     def close


### PR DESCRIPTION
I found that the proxy now does not close unhealthy connections, e.g. when upstream is offline and back again. 
Since this place will log error about upstream broken pipe, I thought it will be safe to close this unhealthy connection here