### PR TITLE
fix: close upstream when pipe is broken also by sending to upstream

### DIFF
--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -92,6 +92,7 @@ module AMQProxy
       nil
     rescue ex : Errno | IO::EOFError
       @log.error "Error sending to upstream: #{ex.inspect}"
+      close
       @close_channel.send nil
       nil
     end


### PR DESCRIPTION
according to the pull request from @Kaggggggga #8: the upstream should also be closed in the write method when pipe is broken