### PR TITLE
Use crystal as build image and alpine as run image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
-FROM crystallang/crystal
+FROM crystallang/crystal:latest-alpine as build
 WORKDIR /app
 COPY . .
-RUN shards build --release --production
+RUN shards build --release --production --static
+
+FROM alpine:latest
+
+WORKDIR /app
+COPY --from=build /app/bin /app/bin
 
 ENV LISTEN_ADDRESS=0.0.0.0
 ENV LISTEN_PORT=5673


### PR DESCRIPTION
This changes the size of the resulting container from `~561MB` to `~21MB`