### PR TITLE
Include timestamps for logging when in debug mode

### DIFF
--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -13,8 +13,14 @@ module AMQProxy
     def initialize(upstream_host, upstream_port, upstream_tls, log_level = Logger::INFO)
       @log = Logger.new(STDOUT)
       @log.level = log_level
-      @log.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
-        io << "\r" << message
+      if(@log.level == Logger::DEBUG)
+        @log.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
+          io << "\r" << datetime << " : " << message
+        end
+      else
+        @log.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
+          io << "\r" << message
+        end
       end
       @clients = Array(Client).new
       @pool = Pool.new(upstream_host, upstream_port, upstream_tls, @log)

--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -13,7 +13,7 @@ module AMQProxy
     def initialize(upstream_host, upstream_port, upstream_tls, log_level = Logger::INFO)
       @log = Logger.new(STDOUT)
       @log.level = log_level
-      if(@log.level == Logger::DEBUG)
+      if @log.level == Logger::DEBUG
         @log.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
           io << "\r" << datetime << " : " << message
         end


### PR DESCRIPTION
This commit introduces timestamps in the log fomatter output when starting amqproxy in debug mode, making diagnosing intermittent connection problems easier.

![image](https://user-images.githubusercontent.com/111710/96920027-ebec6280-14ac-11eb-8d50-7c173d7ea2a3.png)

These are my first lines of crystal, so please be gentle to me.
I figured creating the specific new logger function would be more performant than doing the if/else check on every log entry.