### PR TITLE
Make logs more parseable when in debug mode

### DIFF
--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -15,7 +15,7 @@ module AMQProxy
       @log.level = log_level
       if @log.level == Logger::DEBUG
         @log.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
-          io << "\r" << datetime << " : " << message
+          io << "\n" << datetime << " : " << message
         end
       else
         @log.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|


### PR DESCRIPTION
\r for "newlines" has side effects that i had planned to resolve in the previous commit.