### PR TITLE
Pop connection off of connection pool instead of shift

### DIFF
--- a/src/amqproxy/pool.cr
+++ b/src/amqproxy/pool.cr
@@ -14,7 +14,7 @@ module AMQProxy
     def borrow(user : String, password : String, vhost : String, &block : Upstream -> _)
       u = @lock.synchronize do
         q = @pools[{ user, password, vhost }]
-        q.shift do
+        q.pop do
           @size += 1
           Upstream.new(@host, @port, @tls, @log).connect(user, password, vhost)
         end


### PR DESCRIPTION
First off... I am not too familiar with crystal-lang so let me know if I'm misunderstanding how this works.

The current behavior seems to `shift` a connection off the connection pool/queue, which grabs a connection off the front of the pool/queue and then `push` the connection to the end of the connection pool/queue if it's a valid connection. This seems to cause AMQProxy to cycle through the entire pool and mark every connection as fresh and only shrink the pool during periods where it is extremely idle. The behavior I'm currently seeing is AMQProxy will open a lot of upstream connections if there is a sudden burst of client connections (expected behavior) and then after the burst disappears, we never see the number of active upstream connections shrink back down.

Very open to ideas here, so let me know if I'm missing any context or misunderstanding how this code is working!