### PR TITLE
Graceful shutdown (drain client connections)

### DIFF
--- a/config/example.ini
+++ b/config/example.ini
@@ -3,6 +3,7 @@ log_level = debug
 idle_connection_timeout = 5
 upstream = amqp://localhost:5672
 graceful_shutdown = true
+graceful_shutdown_timeout = 1800
 
 [listen]
 address = 127.0.0.1

--- a/config/example.ini
+++ b/config/example.ini
@@ -2,6 +2,7 @@
 log_level = debug
 idle_connection_timeout = 5
 upstream = amqp://localhost:5672
+graceful_shutdown = true
 
 [listen]
 address = 127.0.0.1

--- a/spec/amqproxy_spec.cr
+++ b/spec/amqproxy_spec.cr
@@ -1,6 +1,75 @@
 require "./spec_helper"
 
 describe AMQProxy::Server do
+  it "graceful shutdown" do
+    started = Time.utc.to_unix
+
+    s = AMQProxy::Server.new("127.0.0.1", 5672, false, Logger::DEBUG, 5, true)
+    channel = Channel(Nil).new
+    spawn do
+      s.listen("127.0.0.1", 5673)
+      channel.send(nil) # send 6
+    end
+    Fiber.yield
+    spawn do
+      AMQP::Client.start("amqp://localhost:5673") do |conn|
+        conn.channel
+        channel.send(nil) # send 0
+        10.times do
+          s.client_connections.should be >= 1
+          s.upstream_connections.should be >= 1
+          sleep 1
+        end
+      end
+      channel.send(nil) # send 5
+    end
+    channel.receive # wait 0
+    s.client_connections.should eq 1
+    s.upstream_connections.should eq 1
+    spawn do
+      AMQP::Client.start("amqp://localhost:5673") do |conn|
+        conn.channel
+        channel.send(nil) # send 2
+        sleep 2
+      end
+      channel.send(nil) # send 3
+    end
+    channel.receive # wait 2
+    s.client_connections.should eq 2
+    s.upstream_connections.should eq 2
+    spawn s.close
+    channel.receive # wait 3
+    s.client_connections.should eq 1
+    s.upstream_connections.should eq 2 # since connection stays open
+    channel_test = Channel(Bool).new
+    spawn do
+      begin
+        AMQP::Client.start("amqp://localhost:5673") do |conn|
+          conn.channel
+          channel_test.send(false) # send 4
+          sleep 1
+        end
+      rescue ex
+        puts ex.message
+        # ex.message.should be "Error reading socket: Connection reset by peer"
+        channel_test.send(true) # send 4
+      end
+    end
+    Fiber.yield
+    channel_test.receive.should be_true # wait 4
+    s.client_connections.should eq 1 # since the new connection should not have worked
+    s.upstream_connections.should eq 2 # since connections stay open
+    channel.receive # wait 5
+    s.running.should eq true
+    s.client_connections.should eq 0 # since now the server should be closed
+    s.upstream_connections.should eq 1
+    channel.receive # wait 6
+    s.client_connections.should eq 0
+    s.upstream_connections.should eq 0
+    s.running.should eq false
+    (Time.utc.to_unix - started).should be < 30
+  end
+
   it "keeps connections open" do
     s = AMQProxy::Server.new("127.0.0.1", 5672, false, Logger::DEBUG)
     begin

--- a/spec/amqproxy_spec.cr
+++ b/spec/amqproxy_spec.cr
@@ -1,72 +1,71 @@
 require "./spec_helper"
 
 describe AMQProxy::Server do
-  it "graceful shutdown" do
+  it "supports waiting for client connections on graceful shutdown" do
     started = Time.utc.to_unix
+    graceful_shutdown = true
 
-    s = AMQProxy::Server.new("127.0.0.1", 5672, false, Logger::DEBUG, 5, true)
-    channel = Channel(Nil).new
+    s = AMQProxy::Server.new("127.0.0.1", 5672, false, Logger::DEBUG, 5, graceful_shutdown)
+    wait_for_channel = Channel(Int32).new # channel used to wait for certain calls, to test certain behaviour
     spawn do
       s.listen("127.0.0.1", 5673)
-      channel.send(nil) # send 6
+      wait_for_channel.send(6) # send 6
     end
     Fiber.yield
     spawn do
       AMQP::Client.start("amqp://localhost:5673") do |conn|
         conn.channel
-        channel.send(nil) # send 0
+        wait_for_channel.send(0) # send 0
         10.times do
           s.client_connections.should be >= 1
           s.upstream_connections.should be >= 1
           sleep 1
         end
       end
-      channel.send(nil) # send 5
+      wait_for_channel.send(5) # send 5
     end
-    channel.receive # wait 0
+    wait_for_channel.receive.should eq 0 # wait 0
     s.client_connections.should eq 1
     s.upstream_connections.should eq 1
     spawn do
       AMQP::Client.start("amqp://localhost:5673") do |conn|
         conn.channel
-        channel.send(nil) # send 2
+        wait_for_channel.send(2) # send 2
         sleep 2
       end
-      channel.send(nil) # send 3
+      wait_for_channel.send(3) # send 3
     end
-    channel.receive # wait 2
+    wait_for_channel.receive.should eq 2  # wait 2
     s.client_connections.should eq 2
     s.upstream_connections.should eq 2
     spawn s.close
-    channel.receive # wait 3
+    wait_for_channel.receive.should eq 3 # wait 3
     s.client_connections.should eq 1
     s.upstream_connections.should eq 2 # since connection stays open
-    channel_test = Channel(Bool).new
     spawn do
       begin
         AMQP::Client.start("amqp://localhost:5673") do |conn|
           conn.channel
-          channel_test.send(false) # send 4
+          wait_for_channel.send(-1) # send 4 (this should not happen)
           sleep 1
         end
       rescue ex
         puts ex.message
         # ex.message.should be "Error reading socket: Connection reset by peer"
-        channel_test.send(true) # send 4
+        wait_for_channel.send(4) # send 4
       end
     end
-    Fiber.yield
-    channel_test.receive.should be_true # wait 4
+    wait_for_channel.receive.should eq 4 # wait 4
     s.client_connections.should eq 1 # since the new connection should not have worked
     s.upstream_connections.should eq 2 # since connections stay open
-    channel.receive # wait 5
-    s.running.should eq true
+    wait_for_channel.receive.should eq 5 # wait 5
+    s.running?.should eq true
     s.client_connections.should eq 0 # since now the server should be closed
     s.upstream_connections.should eq 1
-    channel.receive # wait 6
+    wait_for_channel.receive.should eq 6 # wait 6
     s.client_connections.should eq 0
     s.upstream_connections.should eq 0
-    s.running.should eq false
+    s.running?.should eq false
     (Time.utc.to_unix - started).should be < 30
   end
 

--- a/src/amqproxy.cr
+++ b/src/amqproxy.cr
@@ -25,7 +25,7 @@ class AMQProxy::CLI
           when "graceful_shutdown"         then @graceful_shutdown = (value == "true")
           when "graceful_shutdown_timeout" then @graceful_shutdown_timeout = value.to_i
           when "idle_connection_timeout"   then @idle_connection_timeout = value.to_i
-          else                                raise "Unsupported config #{name}/#{key}"
+          else                                  raise "Unsupported config #{name}/#{key}"
           end
         end
       when "listen"

--- a/src/amqproxy.cr
+++ b/src/amqproxy.cr
@@ -9,6 +9,7 @@ class AMQProxy::CLI
   @listen_address = ENV["LISTEN_ADDRESS"]? || "localhost"
   @listen_port = ENV["LISTEN_PORT"]? || 5673
   @log_level : Logger::Severity = Logger::INFO
+  @graceful_shutdown = false
   @idle_connection_timeout = 5
   @upstream = ENV["AMQP_URL"]?
 
@@ -20,6 +21,7 @@ class AMQProxy::CLI
           case key
           when "upstream"                then @upstream = value
           when "log_level"               then @log_level = Logger::Severity.parse(value)
+          when "graceful_shutdown"       then @graceful_shutdown = (value == "true")
           when "idle_connection_timeout" then @idle_connection_timeout = value.to_i
           else                                raise "Unsupported config #{name}/#{key}"
           end
@@ -51,6 +53,7 @@ class AMQProxy::CLI
         @idle_connection_timeout = v.to_i
       end
       parser.on("-d", "--debug", "Verbose logging") { @log_level = Logger::DEBUG }
+      parser.on("-g", "--graceful_shutdown", "Reject new connections and wait for established conenctions to be closed before shutting down") { @graceful_shutdown = true }
       parser.on("-c FILE", "--config=FILE", "Load config file") { |v| parse_config(v) }
       parser.on("-h", "--help", "Show this help") { puts parser.to_s; exit 0 }
       parser.on("-v", "--version", "Display version") { puts AMQProxy::VERSION.to_s; exit 0 }
@@ -71,9 +74,14 @@ class AMQProxy::CLI
     port = u.port || default_port
     tls = u.scheme == "amqps"
 
-    server = AMQProxy::Server.new(u.host || "", port, tls, @log_level, @idle_connection_timeout)
+    server = AMQProxy::Server.new(u.host || "", port, tls, @log_level, @idle_connection_timeout, @graceful_shutdown)
 
+    @got_sigterm = false
     shutdown = ->(_s : Signal) do
+      if @got_sigterm
+        return
+      end
+      @got_sigterm = true
       server.close
       exit 0
     end

--- a/src/amqproxy.cr
+++ b/src/amqproxy.cr
@@ -55,8 +55,8 @@ class AMQProxy::CLI
         @idle_connection_timeout = v.to_i
       end
       parser.on("-d", "--debug", "Verbose logging") { @log_level = Logger::DEBUG }
-      parser.on("-g", "--graceful_shutdown", "Reject new connections and wait for established connections to be closed before shutting down") { @graceful_shutdown = true }
-      parser.on("-f GRACEFUL_SHUTDOWN_TIMEOUT", "--graceful_shutdown_timeout=SECONDS", "If using graceful_shutdown: Maximum time in seconds to wait until forcing shutdown (disable: 0, default: 0)") do |v|
+      parser.on("-g", "--graceful-shutdown", "Reject new connections and wait for established connections to be closed before shutting down") { @graceful_shutdown = true }
+      parser.on("-f GRACEFUL_SHUTDOWN_TIMEOUT", "--graceful-shutdown-timeout=SECONDS", "If using graceful-shutdown: Maximum time in seconds to wait until forcing shutdown (disable: 0, default: 0)") do |v|
         @graceful_shutdown_timeout = v.to_i
       end
       parser.on("-c FILE", "--config=FILE", "Load config file") { |v| parse_config(v) }
@@ -81,13 +81,13 @@ class AMQProxy::CLI
 
     server = AMQProxy::Server.new(u.host || "", port, tls, @log_level, @idle_connection_timeout, @graceful_shutdown, @graceful_shutdown_timeout)
 
-    @got_sigterm = false
+    @got_shutdown_signal = false
     shutdown = ->(_s : Signal) do
-      if @got_sigterm
-        server.close(true) if _s == Signal::INT
-        return
+      if @got_shutdown_signal
+        server.close(true)
+        exit 0
       end
-      @got_sigterm = true
+      @got_shutdown_signal = true
       server.close
       exit 0
     end

--- a/src/amqproxy/client.cr
+++ b/src/amqproxy/client.cr
@@ -6,6 +6,7 @@ module AMQProxy
     @closed = false
 
     def initialize(@socket : (TCPSocket | OpenSSL::SSL::Socket::Server))
+      @started = Time.utc
     end
 
     def read_loop(upstream : Upstream)
@@ -69,6 +70,14 @@ module AMQProxy
     def close_socket
       @closed = true
       @socket.close rescue nil
+    end
+
+    def socket
+      @socket
+    end
+
+    def lifetime
+      Time.utc - @started
     end
 
     def self.negotiate(socket)

--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -101,7 +101,7 @@ module AMQProxy
             @log.debug "- Client #{client.socket.as(TCPSocket).remote_address} since #{(client.lifetime.total_minutes.floor.to_i)}m #{client.lifetime.seconds}s"
           end
         end
-        if @graceful_shutdown_timeout > 0 && current_time - drain_started > @graceful_shutdown_timeout
+        if @graceful_shutdown_timeout > 0 && Time.utc.to_unix - drain_started > @graceful_shutdown_timeout
           @log.info "Forcing shutdown after #{@graceful_shutdown_timeout} seconds"
           break
         end

--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -42,6 +42,10 @@ module AMQProxy
       @pool.size
     end
 
+    def running
+      @running
+    end
+
     def listen(address, port)
       @socket = socket = TCPServer.new(address, port)
       @log.info "Proxy listening on #{socket.local_address}"

--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -42,7 +42,7 @@ module AMQProxy
       @pool.size
     end
 
-    def running
+    def running?
       @running
     end
 


### PR DESCRIPTION
…T: Reject new connections and wait for established connections to be closed by remote before exiting

Reference: https://github.com/cloudamqp/amqproxy/issues/72

Please review this thoroughly. I code professionally, but I have never used Crystal before.

I tested everything and it seems to work - let me know if there is something not quite right

Many thanks and best,
Marvin