### PR TITLE
Graceful shutdown

### DIFF
--- a/spec/amqproxy_spec.cr
+++ b/spec/amqproxy_spec.cr
@@ -61,4 +61,65 @@ describe AMQProxy::Server do
       system("#{MAYBE_SUDO}rabbitmqctl eval 'application:set_env(rabbit, heartbeat, 60).' > /dev/null").should be_true
     end
   end
+
+  it "supports waiting for client connections on graceful shutdown" do
+    started = Time.utc.to_unix
+
+    s = AMQProxy::Server.new("127.0.0.1", 5672, false, Logger::DEBUG, 5)
+    wait_for_channel = Channel(Int32).new # channel used to wait for certain calls, to test certain behaviour
+    spawn do
+      s.listen("127.0.0.1", 5673)
+    end
+    Fiber.yield
+    spawn do
+      AMQP::Client.start("amqp://localhost:5673") do |conn|
+        conn.channel
+        wait_for_channel.send(0) # send 0
+        10.times do
+          s.client_connections.should be >= 1
+          s.upstream_connections.should be >= 1
+          sleep 1
+        end
+      end
+      wait_for_channel.send(5) # send 5
+    end
+    wait_for_channel.receive.should eq 0 # wait 0
+    s.client_connections.should eq 1
+    s.upstream_connections.should eq 1
+    spawn do
+      AMQP::Client.start("amqp://localhost:5673") do |conn|
+        conn.channel
+        wait_for_channel.send(2) # send 2
+        sleep 2
+      end
+      wait_for_channel.send(3) # send 3
+    end
+    wait_for_channel.receive.should eq 2 # wait 2
+    s.client_connections.should eq 2
+    s.upstream_connections.should eq 2
+    spawn s.stop_accepting_clients
+    wait_for_channel.receive.should eq 3 # wait 3
+    s.client_connections.should eq 1
+    s.upstream_connections.should eq 2 # since connection stays open
+    spawn do
+      begin
+        AMQP::Client.start("amqp://localhost:5673") do |conn|
+          conn.channel
+          wait_for_channel.send(-1) # send 4 (this should not happen)
+          sleep 1
+        end
+      rescue ex
+        puts ex.message
+        # ex.message.should be "Error reading socket: Connection reset by peer"
+        wait_for_channel.send(4) # send 4
+      end
+    end
+    wait_for_channel.receive.should eq 4 # wait 4
+    s.client_connections.should eq 1     # since the new connection should not have worked
+    s.upstream_connections.should eq 2   # since connections stay open
+    wait_for_channel.receive.should eq 5 # wait 5
+    s.client_connections.should eq 0     # since now the server should be closed
+    s.upstream_connections.should eq 1
+    (Time.utc.to_unix - started).should be < 30
+  end
 end

--- a/spec/amqproxy_spec.cr
+++ b/spec/amqproxy_spec.cr
@@ -17,7 +17,7 @@ describe AMQProxy::Server do
       s.client_connections.should eq 0
       s.upstream_connections.should eq 1
     ensure
-      s.close
+      s.stop_accepting_clients
     end
   end
 
@@ -40,7 +40,7 @@ describe AMQProxy::Server do
       s.client_connections.should eq(0)
       s.upstream_connections.should eq(1)
     ensure
-      s.close
+      s.stop_accepting_clients
     end
   end
 
@@ -57,7 +57,7 @@ describe AMQProxy::Server do
       s.client_connections.should eq(0)
       s.upstream_connections.should eq(1)
     ensure
-      s.close
+      s.stop_accepting_clients
       system("#{MAYBE_SUDO}rabbitmqctl eval 'application:set_env(rabbit, heartbeat, 60).' > /dev/null").should be_true
     end
   end

--- a/src/amqproxy.cr
+++ b/src/amqproxy.cr
@@ -73,14 +73,24 @@ class AMQProxy::CLI
 
     server = AMQProxy::Server.new(u.host || "", port, tls, @log_level, @idle_connection_timeout)
 
+    first_shutdown = true
     shutdown = ->(_s : Signal) do
-      server.close
-      exit 0
+      if first_shutdown
+        first_shutdown = false
+        server.stop_accepting_clients
+      else
+        server.disconnect_clients
+      end
     end
     Signal::INT.trap &shutdown
     Signal::TERM.trap &shutdown
 
     server.listen(@listen_address, @listen_port.to_i)
+
+    # wait until all client connections are closed
+    until server.client_connections.zero?
+      sleep 0.2
+    end
   end
 end
 

--- a/src/amqproxy/client.cr
+++ b/src/amqproxy/client.cr
@@ -3,9 +3,7 @@ require "amq-protocol"
 
 module AMQProxy
   struct Client
-    @closed = false
-
-    def initialize(@socket : (TCPSocket | OpenSSL::SSL::Socket::Server))
+    def initialize(@socket : TCPSocket)
     end
 
     def read_loop(upstream : Upstream)
@@ -30,11 +28,10 @@ module AMQProxy
     rescue ex : Upstream::WriteError
       upstream_disconnected
     rescue ex : IO::EOFError
-      raise Error.new("Client disconnected", ex) unless @closed
+      raise Error.new("Client disconnected", ex) unless @socket.closed?
     rescue ex
       raise ReadError.new "Client read error", ex
     ensure
-      @closed = true
       @socket.close rescue nil
     end
 
@@ -46,10 +43,9 @@ module AMQProxy
       socket.flush
       case frame
       when AMQ::Protocol::Frame::Connection::CloseOk
-        @closed = true
         socket.close
       end
-    rescue ex : Socket::Error | OpenSSL::SSL::Error
+    rescue ex : Socket::Error
       raise WriteError.new "Error writing to client", ex
     end
 
@@ -67,7 +63,6 @@ module AMQProxy
     end
 
     def close_socket
-      @closed = true
       @socket.close rescue nil
     end
 

--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -1,5 +1,4 @@
 require "socket"
-require "openssl"
 require "logger"
 require "amq-protocol"
 require "./pool"

--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -1,6 +1,5 @@
 require "socket"
 require "openssl"
-require "uri"
 require "./client"
 
 module AMQProxy


### PR DESCRIPTION
Fixes #72 

No timeout on graceful shutdown, but a second TERM/INT will force close connect clients. And normally you have a shutdown timeout in the systemd unit or kubernetes pod. 