### PR TITLE
add locks on write operations (fix invalid_frame_end_marker issue) Upstream & Client

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - v*
 
 name: Create Release
 
@@ -10,27 +10,23 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - name: Checkout the repository
+        run: git clone ${{ github.repositoryUrl }} .
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build static tar package
+        uses: docker/build-push-action@v3
         with:
-          fetch-depth: 0 # to be able to figure out which is next to latest tag
-
-      # Needed because of https://github.com/actions/checkout/issues/290
-      - name: Fetch annotated tags
-        run: git fetch --force --tags
-
-      - name: Construct the release notes
-        run: |
-          echo 'RELEASE_NOTES<<EOF' >> $GITHUB_ENV
-          ./build/release_notes >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          file: tar.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          outputs: .
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+        run: gh release create "${{ github.ref }}" ./*.tar.gz --notes "$(./build/release_notes)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: ${{ env.RELEASE_NOTES }}

--- a/build/deb
+++ b/build/deb
@@ -14,7 +14,9 @@ mkdir -p debroot/usr/share/man/man1
 cp bin/amqproxy debroot/usr/bin
 #strip --strip-unneeded --remove-section=.comment --remove-section=.note debroot/usr/bin/*
 cp extras/amqproxy.service debroot/lib/systemd/system
+cp config/example.ini debroot/etc/amqproxy.ini
 cp README.md debroot/usr/share/doc/amqproxy/README
+cp CHANGELOG.md debroot/usr/share/doc/amqproxy/changelog
 cat > debroot/usr/share/doc/amqproxy/changelog.Debian << EOF
 amqproxy ($pkg_version-$pkg_revision) whatever; urgency=medium
 

--- a/config/example.ini
+++ b/config/example.ini
@@ -1,5 +1,5 @@
 [main]
-log_level = debug
+log_level = info
 idle_connection_timeout = 5
 upstream = amqp://localhost:5672
 

--- a/extras/amqproxy.service
+++ b/extras/amqproxy.service
@@ -5,7 +5,7 @@ Requires=network.target
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/amqproxy -p 5673 amqp://127.0.0.1:5672
+ExecStart=/usr/bin/amqproxy --config /etc/amqproxy.ini
 Restart=on-failure
 DynamicUser=yes
 LimitNOFILE=infinity

--- a/src/amqproxy/client.cr
+++ b/src/amqproxy/client.cr
@@ -4,8 +4,9 @@ require "./version"
 
 module AMQProxy
   struct Client
+    @lock = Mutex.new
+
     def initialize(@socket : TCPSocket)
-      @lock = Mutex.new
     end
 
     def read_loop(upstream : Upstream)

--- a/tar.Dockerfile
+++ b/tar.Dockerfile
@@ -1,0 +1,14 @@
+FROM 84codes/crystal:latest-alpine AS builder
+WORKDIR /usr/src/amqproxy
+COPY shard.yml shard.lock ./
+RUN shards install --production
+COPY src/ src/
+RUN shards build --production --release --static --debug
+COPY README.md LICENSE extras/amqproxy.service amqproxy/
+COPY config/example.ini amqproxy/amqproxy.ini
+RUN mv bin/* amqproxy/
+ARG TARGETARCH
+RUN tar zcvf amqproxy-$(shards version)_static-$TARGETARCH.tar.gz amqproxy/
+
+FROM scratch
+COPY --from=builder /usr/src/amqproxy/*.tar.gz .


### PR DESCRIPTION
This fixes issue: https://github.com/cloudamqp/amqproxy/issues/88
It's solved by Upstream write lock.
I've added additionally lock on writing to Client - just to be sure - it's not necessary, but performance was not affected so I left it.