### PR TITLE
[ISSUE-97] Adding max upstream connection configuration

### DIFF
--- a/src/amqproxy.cr
+++ b/src/amqproxy.cr
@@ -52,7 +52,7 @@ class AMQProxy::CLI
       parser.on("-t IDLE_CONNECTION_TIMEOUT", "--idle-connection-timeout=SECONDS", "Maxiumum time in seconds an unused pooled connection stays open (default 5s)") do |v|
         @idle_connection_timeout = v.to_i
       end
-      parser.on("-t MAX_UPSTREAM_CONNECTIONS", "--max-pool-size=POOL_SIZE", "Maximum amount of connections proxy will open to upstream. (Default -1, unlimited)") do |v|
+      parser.on("-t MAX_UPSTREAM_CONNECTIONS", "--max-upstream-connections=UPSTREAM_MAX", "Maximum amount of connections proxy will open to upstream. (Default -1, unlimited)") do |v|
         @max_upstream_connections = v.to_i
       end
       parser.on("-d", "--debug", "Verbose logging") { @log_level = Logger::DEBUG }

--- a/src/amqproxy.cr
+++ b/src/amqproxy.cr
@@ -52,7 +52,7 @@ class AMQProxy::CLI
       parser.on("-t IDLE_CONNECTION_TIMEOUT", "--idle-connection-timeout=SECONDS", "Maxiumum time in seconds an unused pooled connection stays open (default 5s)") do |v|
         @idle_connection_timeout = v.to_i
       end
-      parser.on("-t MAX_UPSTREAM_CONNECTIONS", "--max-upstream-connections=UPSTREAM_MAX", "Maximum amount of connections proxy will open to upstream. (Default -1, unlimited)") do |v|
+      parser.on("-m MAX_UPSTREAM_CONNECTIONS", "--max-upstream-connections=UPSTREAM_MAX", "Maximum amount of connections proxy will open to upstream. (Default -1, unlimited)") do |v|
         @max_upstream_connections = v.to_i
       end
       parser.on("-d", "--debug", "Verbose logging") { @log_level = Logger::DEBUG }

--- a/src/amqproxy/pool.cr
+++ b/src/amqproxy/pool.cr
@@ -25,8 +25,8 @@ module AMQProxy
             c = Upstream.new(@host, @port, @tls_ctx, @log).connect(user, password, vhost)
             @size += 1
           else
-            @log.error "Max upstream connections reached"
-            raise Upstream::MaxConnectionError.new("Max upstream connections reached")
+            @log.error "Max upstream connections reached. Pool size: #{@size}/#{@max_pool_size}"
+            raise Upstream::MaxConnectionError.new("Max upstream connections reached. Pool size: #{@size}/#{@max_pool_size}")
           end
         end
         c.current_client = client

--- a/src/amqproxy/pool.cr
+++ b/src/amqproxy/pool.cr
@@ -21,7 +21,7 @@ module AMQProxy
         if c.nil? || c.closed?
           @log.debug("Pool size: #{@size}/#{@max_pool_size}")
           # no pool limit (-1) or limit new upstream connections
-          if @max_pool_size < 0 || (@max_pool_size > 0 && @size < @max_pool_size)
+          if @max_pool_size < 0 || @size < @max_pool_size
             c = Upstream.new(@host, @port, @tls_ctx, @log).connect(user, password, vhost)
             @size += 1
           else

--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -87,9 +87,8 @@ module AMQProxy
         close.to_io socket, IO::ByteFormat::NetworkEndian
         socket.flush
       rescue ex : Upstream::MaxConnectionError
-        @log.error { "Upstream error for user '#{user}' to vhost '#{vhost}': #{ex.inspect} (cause: #{ex.cause.inspect})" }
-        # TODO - What's the appropriate frame to close?
-        close = AMQ::Protocol::Frame::Connection::Close.new(403_u16, "UPSTREAM_ERROR", 0_u16, 0_u16)
+        @log.error { "Max upstream connections reached: #{ex.inspect} (cause: #{ex.cause.inspect})" }
+        close = AMQ::Protocol::Frame::Connection::Close.new(403_u16, "MAX_UPSTREAM_CONNECTIONS", 0_u16, 0_u16)
         close.to_io socket, IO::ByteFormat::NetworkEndian
         socket.flush
       end

--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -213,5 +213,7 @@ module AMQProxy
     class AccessError < Error; end
 
     class WriteError < Error; end
+
+    class MaxConnectionError < Error; end
   end
 end


### PR DESCRIPTION
As discussed in #97.

Adds a `max_upstream_connections` options that will fail creating additional upstream connections from being made. This is an attempt to preserve the upstream from becoming overwhelmed.

Questions / Things that are broken:
* I have not been able to write a good test for this. Is there a better mechanism to "trick" the active client to use a new upstream connection in the spec?
* I am unsure what the best closing frame would be to send to the client (`server.cr::91` TODO)