### PR TITLE
Added error handling for IO error

### DIFF
--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -86,6 +86,10 @@ module AMQProxy
         close = AMQ::Protocol::Frame::Connection::Close.new(403_u16, "UPSTREAM_ERROR", 0_u16, 0_u16)
         close.to_io socket, IO::ByteFormat::NetworkEndian
         socket.flush
+      rescue ex : IO::Error
+        @log.error { "IO Error for user '#{user}' to vhost '#{vhost}': #{ex.message}" }
+        close = AMQ::Protocol::Frame::Connection::Close.new(403_u16, "IO_ERROR", 0_u16, 0_u16)
+        close.to_io socket, IO::ByteFormat::NetworkEndian
       end
     rescue ex : Client::Error
       @log.debug { "Client disconnected: #{remote_address}: #{ex.inspect}" }


### PR DESCRIPTION
Adding error message and close connection for clients when the connection between RabbitMQ and AMQProxy is closed.

- Probably related to issue: Upstream connection timeout #98
- have had a couple customers internally recently too

To reproduce.
- Use client that reconnects automatically:
- Set up AMQProxy to a RabbitMQ cluster. 
- Simulate network issue between AMQProxy/RabbitMQ (e.g. block traffic using nftables and force close connection in RMQ).
- Client will reconnect to AMQProxy, but AMQProxy won't be able to connect to RabbitMQ. AMQProxy will throw an  IO Error.

This PR will ensure error is logged, and client is disconnected (as connection is broken to the cluster). 