### PR TITLE
Disables the Nagle algorithm on the upstream socket as well

### DIFF
--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -18,6 +18,7 @@ module AMQProxy
       tcp_socket.tcp_keepalive_idle = 60
       tcp_socket.tcp_keepalive_count = 3
       tcp_socket.tcp_keepalive_interval = 10
+      tcp_socket.tcp_nodelay = true
       @socket =
         if tls_ctx = @tls_ctx
           OpenSSL::SSL::Socket::Client.new(tcp_socket, tls_ctx, hostname: @host).tap do |c|


### PR DESCRIPTION
With nagle algorithm on the upstream socket I only get ~20msg/s throughput locally.
Without it ~8000.

Does not seem to matter if the client socket has it enabled or not.