### PR TITLE
Lint + bump Crystal version in `shard.yml`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -20,6 +20,6 @@ development_dependencies:
   ameba:
     github: crystal-ameba/ameba
 
-crystal: 1.5.0
+crystal: 1.9.2
 
 license: MIT

--- a/src/amqproxy/pool.cr
+++ b/src/amqproxy/pool.cr
@@ -15,7 +15,7 @@ module AMQProxy
       spawn shrink_pool_loop, name: "shrink pool loop"
     end
 
-    def borrow(user : String, password : String, vhost : String, client : Client, &block : Upstream -> _)
+    def borrow(user : String, password : String, vhost : String, client : Client, & : Upstream -> _)
       u = @lock.synchronize do
         c = @pools[{user, password, vhost}].pop?
         if c.nil? || c.closed?

--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -99,7 +99,7 @@ module AMQProxy
       # print "\r#{@clients.size} clients\t\t #{@pool.size} upstreams"
     end
 
-    private def active_client(client)
+    private def active_client(client, &)
       @clients_lock.synchronize do
         @clients << client
       end


### PR DESCRIPTION
Reported in CI: https://github.com/cloudamqp/amqproxy/actions/runs/6250961840/job/16970987715#step:5:1

    src/amqproxy/server.cr:102:17
    [W] Lint/MissingBlockArgument: Missing anonymous block argument. Use `&` as an argument name to indicate yielding method.
    > private def active_client(client)
                  ^-----------^

    src/amqproxy/pool.cr:18:84 [Correctable]
    [W] Lint/UnusedBlockArgument: Use `&` as an argument name to indicate that it won't be referenced.
    > def borrow(user : String, password : String, vhost : String, client : Client, &block : Upstream -> _)
                                                                                     ^---^

I had Crystal 1.5.0 installed locally, but I could not install ameba
with that, so I think it is best to bump.

CI is also always using the latest 84codes/crystal image.