### PR TITLE
Update current client in `Upstream#read_loop`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   push:
     paths:
+      - 'run-specs-in-docker.sh'
       - '.github/workflows/ci.yml'
       - 'shard.yml'
       - 'shard.lock'
@@ -12,28 +13,17 @@ on:
 jobs:
   spec:
     runs-on: ubuntu-latest
-    container: 84codes/crystal:latest-ubuntu-22.04
+    timeout-minutes: 10
     steps:
-      - name: Install RabbitMQ
-        run: apt-get update && apt-get install -y rabbitmq-server
-
-      - name: Start RabbitMQ
-        run: RABBITMQ_PID_FILE=/tmp/rabbitmq.pid rabbitmq-server -detached
-
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install shards
-        run: sed -i '/ameba/d' shard.yml && shards install
-
-      - name: Wait for RabbitMQ to start
-        run: rabbitmqctl wait /tmp/rabbitmq.pid
-
       - name: Run tests
-        run: crystal spec --order random
+        run: ./run-specs-in-docker.sh
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container: 84codes/crystal:latest-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +32,7 @@ jobs:
 
   format:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container: 84codes/crystal:latest-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,25 @@
 # Contributing
 
-_TODO_
+## Development
+
+Run tests in Docker:
+
+```bash
+docker build  . -f spec/Dockerfile -t amqproxy_spec
+docker run --rm -it -v $(pwd):/app -w /app --entrypoint bash amqproxy_spec
+
+# ensure rabbitmq is up, run all specs
+./entrypoint.sh
+
+# run single spec
+crystal spec --example "keeps connections open"
+```
+
+Run tests using Docker Compose:
+
+```bash
+./run-specs-in-docker.sh
+```
 
 ## Release
 

--- a/run-specs-in-docker.sh
+++ b/run-specs-in-docker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -x
+set -e
+
+docker compose \
+  --file spec/docker-compose.yml \
+  up \
+  --remove-orphans \
+  --force-recreate \
+  --renew-anon-volumes \
+  --build \
+  --exit-code-from spec

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -1,0 +1,16 @@
+FROM 84codes/crystal:latest-ubuntu-22.04
+
+RUN apt-get update && apt-get install -y rabbitmq-server
+
+WORKDIR /tmp
+
+# We want to install shards before copying code/spec files for quicker runs
+COPY shard.yml shard.lock ./
+RUN shards install
+
+COPY src/ src/
+COPY spec/ spec/
+
+COPY spec/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.8"
+services:
+  spec:
+    build:
+      context: ..
+      dockerfile: spec/Dockerfile

--- a/spec/entrypoint.sh
+++ b/spec/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -u
+set -x
+
+export RABBITMQ_PID_FILE=/tmp/rabbitmq.pid
+
+# Start RabbitMQ
+rabbitmq-server -detached
+
+# Wait for RabbitMQ to start
+rabbitmqctl wait $RABBITMQ_PID_FILE
+
+crystal --version
+crystal spec --order random

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,3 +4,33 @@ require "../src/amqproxy/version"
 require "amqp-client"
 
 MAYBE_SUDO = (ENV.has_key?("NO_SUDO") || `id -u` == "0\n") ? "" : "sudo "
+
+# Spec timeout borrowed from Crystal project:
+# https://github.com/crystal-lang/crystal/blob/1.10.1/spec/support/mt_abort_timeout.cr
+
+private SPEC_TIMEOUT = 15.seconds
+
+Spec.around_each do |example|
+  done = Channel(Exception?).new
+
+  spawn(same_thread: true) do
+    begin
+      example.run
+    rescue e
+      done.send(e)
+    else
+      done.send(nil)
+    end
+  end
+
+  timeout = SPEC_TIMEOUT
+
+  select
+  when res = done.receive
+    raise res if res
+  when timeout(timeout)
+    _it = example.example
+    ex = Spec::AssertionFailed.new("spec timed out after #{timeout}", _it.file, _it.line)
+    _it.parent.report(:fail, _it.description, _it.file, _it.line, timeout, ex)
+  end
+end


### PR DESCRIPTION
Fix regression introduced by https://github.com/cloudamqp/amqproxy/pull/128

The current client is updated by the server / pool, when there is a new connection:

https://github.com/cloudamqp/amqproxy/blob/8462a50afbd0bcd9f325edd73bb796ddd9ad3ff1/src/amqproxy/server.cr#L75
https://github.com/cloudamqp/amqproxy/blob/8462a50afbd0bcd9f325edd73bb796ddd9ad3ff1/src/amqproxy/pool.cr#L25


Close https://github.com/cloudamqp/amqproxy/issues/135

Made it easy to run the specs in Docker as they use `sudo` and needs an RabbitMQ instance running – specs weren't completely stable for me when running in macOS. This makes it much easier to start fresh. For CI, this should be the same as we were already using the `container:` keyword.