### PR TITLE
Build packages for Debian 12, remove EoL systems

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -34,7 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: ["ubuntu-jammy", "ubuntu-focal", "ubuntu-bionic", "debian-buster", "debian-bullseye"]
+        os:
+          - ubuntu-jammy    # Ubuntu 22.04
+          - ubuntu-focal    # Ubuntu 20.04
+          - debian-bookworm # Debian 12
+          - debian-bullseye # Debian 11
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
Debian 12 was released 2024-02-10:
https://www.debian.org/releases/bookworm/

Ubuntu 18.04 and Debian 10 has reached end of life: https://www.debian.org/releases/buster/
https://endoflife.software/operating-systems/linux/ubuntu

Fixes https://github.com/cloudamqp/amqproxy/issues/149