### PR TITLE
Normalize error logs to all provide the exception object

### DIFF
--- a/src/amqproxy/channel_pool.cr
+++ b/src/amqproxy/channel_pool.cr
@@ -54,7 +54,7 @@ module AMQProxy
           begin
             u.close "AMQProxy shutdown"
           rescue ex
-            Log.error { "Problem closing upstream: #{ex.inspect}" }
+            Log.error(exception: ex) { "Unable to close upstream connection" }
           end
         end
       end
@@ -70,7 +70,7 @@ module AMQProxy
               begin
                 u.close "Pooled connection closed due to inactivity"
               rescue ex
-                Log.error { "Problem closing upstream: #{ex.inspect}" }
+                Log.error(exception: ex) { "Unable to close upstream connection" }
               end
             elsif u.closed?
               Log.error { "Removing closed upstream connection from pool" }

--- a/src/amqproxy/client.cr
+++ b/src/amqproxy/client.cr
@@ -77,11 +77,11 @@ module AMQProxy
         end
       end
     rescue ex : IO::EOFError
-      Log.debug { "Disconnected" }
+      Log.debug(exception: ex) { "Disconnected" }
     rescue ex : IO::Error
       Log.error(exception: ex) { "IO error" } unless socket.closed?
     rescue ex : Upstream::AccessError
-      Log.error { "Access refused, reason: #{ex.message}" }
+      Log.error(exception: ex) { "Access refused, reason: #{ex.message}" }
       close_connection(403_u16, ex.message || "ACCESS_REFUSED")
     rescue ex : Upstream::Error
       Log.error(exception: ex) { "Upstream error" }

--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -66,7 +66,7 @@ module AMQProxy
         c.read_loop(channel_pool)
       end
     rescue ex # only raise from constructor, when negotating
-      Log.debug { "Client connection failure (#{remote_address}) #{ex.inspect}" }
+      Log.debug(exception: ex) { "Client connection failure (#{remote_address})" }
       socket.close
     end
 


### PR DESCRIPTION
Resolves my comment from https://github.com/cloudamqp/amqproxy/commit/98c0bc7bdc2509d62c2191bc3038ce8ddcb0563d#r138864701. Ensures all error logging passes the exception object via the named arg vs in the message. 