### PR TITLE
Close upstream channel on channel errors

### DIFF
--- a/src/amqproxy/channel_pool.cr
+++ b/src/amqproxy/channel_pool.cr
@@ -39,6 +39,10 @@ module AMQProxy
       upstream = Upstream.new(@host, @port, @tls_ctx, @credentials)
       Log.info { "Adding upstream connection" }
       @upstreams.unshift upstream
+      spawn do
+        upstream.read_loop
+        @upstreams.delete upstream
+      end
     rescue ex : IO::Error
       raise Upstream::Error.new ex.message, cause: ex
     end

--- a/src/amqproxy/client.cr
+++ b/src/amqproxy/client.cr
@@ -49,9 +49,8 @@ module AMQProxy
           end
           write AMQ::Protocol::Frame::Channel::CloseOk.new(frame.channel)
         when AMQ::Protocol::Frame::Channel::CloseOk
-          if upstream_channel = @channel_map.delete(frame.channel)
-            upstream_channel.write(frame)
-          end
+          # CloseOk already sent in Upstream#read_loop
+          @channel_map.delete(frame.channel)
         when frame.channel.zero?
           Log.error { "Unexpected connection frame: #{frame}" }
           close_connection(540_u16, "NOT_IMPLEMENTED", frame)


### PR DESCRIPTION
Prevent reuse of channels closed by upstream. Also remove closed upstream connections from channel pool.

Fixes #154 