### PR TITLE
Error writing to upstream

### DIFF
--- a/src/amqproxy/channel_pool.cr
+++ b/src/amqproxy/channel_pool.cr
@@ -70,7 +70,7 @@ module AMQProxy
         @lock.synchronize do
           (@upstreams.size - 1).times do # leave at least one connection
             u = @upstreams.pop
-            if u.active_channels.zero?
+            if u.channels.zero?
               begin
                 u.close "Pooled connection closed due to inactivity"
               rescue ex

--- a/src/amqproxy/client.cr
+++ b/src/amqproxy/client.cr
@@ -28,6 +28,7 @@ module AMQProxy
     def read_loop(channel_pool, socket = @socket) # ameba:disable Metrics/CyclomaticComplexity
       Log.context.set(remote_address: socket.remote_address.to_s)
       Log.debug { "Connected" }
+      i = 0
       socket.read_timeout = (@heartbeat / 2).ceil.seconds if @heartbeat > 0
       loop do
         case frame = AMQ::Protocol::Frame.from_io(socket, IO::ByteFormat::NetworkEndian)
@@ -65,6 +66,7 @@ module AMQProxy
             close_connection(504_u16, "CHANNEL_ERROR - Channel #{frame.channel} not open", frame)
           end
         end
+        Fiber.yield if (i &+= 1) % 32768 == 0
       rescue IO::TimeoutError
         time_since_last_heartbeat = (Time.monotonic - @last_heartbeat).total_seconds.to_i # ignore subsecond latency
         if time_since_last_heartbeat <= 1 + @heartbeat                                    # add 1s grace because of rounding
@@ -100,7 +102,7 @@ module AMQProxy
         break if frame.is_a? AMQ::Protocol::Frame::Connection::CloseOk
       end
     rescue ex : IO::Error
-      raise ex unless socket.closed?
+      # Client closed connection, suppress error
     ensure
       @outgoing_frames.close
       socket.close rescue nil
@@ -110,6 +112,8 @@ module AMQProxy
     # Send frame to client, channel id should already be remapped by the caller
     def write(frame : AMQ::Protocol::Frame)
       @outgoing_frames.send frame
+      rescue Channel::ClosedError
+        # do nothing
     end
 
     def close_connection(code, text, frame = nil)

--- a/src/amqproxy/client.cr
+++ b/src/amqproxy/client.cr
@@ -112,8 +112,8 @@ module AMQProxy
     # Send frame to client, channel id should already be remapped by the caller
     def write(frame : AMQ::Protocol::Frame)
       @outgoing_frames.send frame
-      rescue Channel::ClosedError
-        # do nothing
+    rescue Channel::ClosedError
+      # do nothing
     end
 
     def close_connection(code, text, frame = nil)

--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -67,7 +67,8 @@ module AMQProxy
       end
     rescue ex # only raise from constructor, when negotating
       Log.debug { "Client connection failure (#{remote_address}) #{ex.inspect}" }
-      socket.close
+    ensure
+      socket.close rescue nil
     end
 
     private def active_client(client, &)

--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -77,7 +77,7 @@ module AMQProxy
     # Frames from upstream (to client)
     def read_loop(socket = @socket) # ameba:disable Metrics/CyclomaticComplexity
       Log.context.set(remote_address: @remote_address)
-      i = 0
+      i = 0u64
       loop do
         case frame = AMQ::Protocol::Frame.from_io(socket, IO::ByteFormat::NetworkEndian)
         when AMQ::Protocol::Frame::Heartbeat then send frame
@@ -109,7 +109,7 @@ module AMQProxy
               "DOWNSTREAM_DISCONNECTED", 0_u16, 0_u16)
           end
         end
-        Fiber.yield if (i &+= 1) % 32768 == 0
+        Fiber.yield if (i &+= 1) % 4096 == 0
       end
     rescue ex : IO::Error | OpenSSL::SSL::Error
       Log.error(exception: ex) { "Error reading from upstream" } unless socket.closed?

--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -112,7 +112,7 @@ module AMQProxy
         Fiber.yield if (i &+= 1) % 4096 == 0
       end
     rescue ex : IO::Error | OpenSSL::SSL::Error
-      Log.error(exception: ex) { "Error reading from upstream" } unless socket.closed?
+      Log.info { "Connection error #{ex.inspect}" } unless socket.closed?
     ensure
       socket.close rescue nil
       close_all_client_channels

--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -52,7 +52,7 @@ module AMQProxy
         send AMQ::Protocol::Frame::Channel::Close.new(channel, 0u16, "", 0u16, 0u16)
       end
     rescue ex : IO::Error | OpenSSL::SSL::Error
-      Log.debug(exception: ex) { "Error while closing upstream channel #{id}" }
+      Log.debug(exception: ex) { "Error while closing upstream channel #{channel}" }
     end
 
     def channels

--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -77,6 +77,7 @@ module AMQProxy
     # Frames from upstream (to client)
     def read_loop(socket = @socket) # ameba:disable Metrics/CyclomaticComplexity
       Log.context.set(remote_address: @remote_address)
+      i = 0
       loop do
         case frame = AMQ::Protocol::Frame.from_io(socket, IO::ByteFormat::NetworkEndian)
         when AMQ::Protocol::Frame::Heartbeat then send frame
@@ -108,6 +109,7 @@ module AMQProxy
               "DOWNSTREAM_DISCONNECTED", 0_u16, 0_u16)
           end
         end
+        Fiber.yield if (i &+= 1) % 32768 == 0
       end
     rescue ex : IO::Error | OpenSSL::SSL::Error
       Log.error(exception: ex) { "Error reading from upstream" } unless socket.closed?

--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -59,10 +59,6 @@ module AMQProxy
       @channels.size
     end
 
-    def active_channels
-      @channels.size
-    end
-
     # Frames from upstream (to client)
     def read_loop(socket = @socket) # ameba:disable Metrics/CyclomaticComplexity
       Log.context.set(remote_address: @remote_address)


### PR DESCRIPTION
WIP: 
This suppress some errors that shouldnt be logged when a channel is already closed. 
Yields fiber read/write loops to make sure we can both publish and consume without locking. 

Adresses some parts of #157 