### PR TITLE
Add Ubuntu 24.04 noble to os matrix

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -35,6 +35,7 @@ jobs:
     strategy:
       matrix:
         os:
+          - ubuntu-noble    # Ubuntu 24.04
           - ubuntu-jammy    # Ubuntu 22.04
           - ubuntu-focal    # Ubuntu 20.04
           - debian-bookworm # Debian 12


### PR DESCRIPTION
Build packages for Ubuntu 24.04 Noble Numbat.