### PR TITLE
Require and use crystal 1.13.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: 84codes/crystal:latest-ubuntu-22.04
+    container: 84codes/crystal:1.13.2-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: shards install
@@ -33,7 +33,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: 84codes/crystal:latest-ubuntu-22.04
+    container: 84codes/crystal:1.13.2-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: crystal tool format --check

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -17,7 +17,7 @@ jobs:
   tar:
     runs-on: ubuntu-latest
     container:
-      image: 84codes/crystal:latest-alpine
+      image: 84codes/crystal:1.13.2-alpine
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies
@@ -58,7 +58,7 @@ jobs:
           file: deb.Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            image=84codes/crystal:latest-${{ matrix.os }}
+            image=84codes/crystal:1.13.2-${{ matrix.os }}
           outputs: builds
 
       - name: Upload GitHub artifact

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -60,7 +60,7 @@ jobs:
           file: Dockerfile.rpm
           platforms: linux/amd64,linux/arm64
           build-args: |
-            build_image=84codes/crystal:latest-${{ matrix.os }}
+            build_image=84codes/crystal:1.13.2-${{ matrix.os }}
             version=${{ env.version }}
           outputs: RPMS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Compile with Crystal 1.13.2, fixes a memory leak in Hash.
+
 ## [v2.0.1] - 2024-07-11
 
 - Return unused memory faster to the OS using GC_UNMAP_THRESHOLD=1 in Dockerfile and systemd service file

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 84codes/crystal:latest-alpine AS builder
+FROM 84codes/crystal:1.13.2-alpine AS builder
 WORKDIR /tmp
 COPY shard.yml shard.lock ./
 RUN shards install --production

--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -1,4 +1,4 @@
-ARG build_image=84codes/crystal:latest-fedora-39
+ARG build_image=84codes/crystal:1.13.2-fedora-39
 
 FROM $build_image AS builder
 RUN dnf install -y --nodocs --setopt=install_weak_deps=False --repo=fedora,updates \

--- a/deb.Dockerfile
+++ b/deb.Dockerfile
@@ -1,4 +1,4 @@
-ARG image=84codes/crystal:latest-debian-11
+ARG image=84codes/crystal:1.13.2-debian-11
 FROM $image AS builder
 RUN apt-get update && \
     env DEBIAN_FRONTEND=noninteractive apt-get install -y dpkg help2man lintian

--- a/set-crystal-version.sh
+++ b/set-crystal-version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+version=$1
+
+if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+then
+  echo "Use: $0 <semver>"
+  exit 1
+fi
+
+files=(
+  Dockerfile
+  Dockerfile.rpm
+  deb.Dockerfile
+  tar.Dockerfile
+  spec/Dockerfile
+  .github/workflows/ci.yml
+  .github/workflows/packages.yml
+  .github/workflows/rpm.yml
+)
+
+suffix='pre-'${version}
+for file in ${files[@]}
+do
+  sed -i'.bak' 's/84codes\/crystal:[^-]*/84codes\/crystal:'${version}'/' ${file}
+  # sed on BSD systems require a backup extension, so we're deleting the backup afterwards
+  rm -f ${file}.bak
+done
+sed -i'.bak' 's/crystal: .*$/crystal: '${version}'/' shard.yml
+rm -f shard.yml.bak

--- a/shard.yml
+++ b/shard.yml
@@ -18,5 +18,5 @@ development_dependencies:
   ameba:
     github: crystal-ameba/ameba
 
-crystal: 1.13.0
+crystal: 1.13.2
 license: MIT

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -1,4 +1,4 @@
-FROM 84codes/crystal:latest-ubuntu-22.04
+FROM 84codes/crystal:1.13.2-ubuntu-22.04
 
 RUN apt-get update && apt-get install -y rabbitmq-server
 

--- a/tar.Dockerfile
+++ b/tar.Dockerfile
@@ -1,4 +1,4 @@
-FROM 84codes/crystal:latest-alpine AS builder
+FROM 84codes/crystal:1.13.2-alpine AS builder
 WORKDIR /usr/src/amqproxy
 COPY shard.yml shard.lock ./
 RUN shards install --production


### PR DESCRIPTION
Require and build with crystal 1.13.2 to get the memory leak in Hash fix.