### PR TITLE
Add client close timeout on term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added config option term_client_close_timeout and cli option --term-client-close-timeout to set how long to wait for clients to close their connections before sending Close when amqproxy receives a TERM signal.
+
 ## [v2.0.2] - 2024-08-25
 
 - Compile with Crystal 1.13.2, fixes a memory leak in Hash.

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -27,3 +27,14 @@ def with_http_server(idle_connection_timeout = 5, &)
     end
   end
 end
+
+def verify_running_amqp!
+  TCPSocket.new("127.0.0.1", 5672, connect_timeout: 3.seconds).close
+rescue Socket::ConnectError
+  STDERR.puts "[ERROR] Specs require a running amqp server on 127.0.0.1:5672"
+  exit 1
+end
+
+Spec.before_suite do
+  verify_running_amqp!
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,8 +1,11 @@
+require "log"
 require "spec"
 require "uri"
 require "../src/amqproxy/server"
 require "../src/amqproxy/version"
 require "amqp-client"
+
+Log.setup_from_env(default_level: :error)
 
 MAYBE_SUDO = (ENV.has_key?("NO_SUDO") || `id -u` == "0\n") ? "" : "sudo "
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,12 +1,20 @@
 require "spec"
+require "uri"
 require "../src/amqproxy/server"
 require "../src/amqproxy/version"
 require "amqp-client"
 
 MAYBE_SUDO = (ENV.has_key?("NO_SUDO") || `id -u` == "0\n") ? "" : "sudo "
 
+UPSTREAM_URL = begin
+  URI.parse ENV.fetch("UPSTREAM_URL", "amqp://127.0.0.1:5672?idle_connection_timeout=5")
+rescue e : URI::Error
+  puts "Invalid UPSTREAM_URL: #{e}"
+  exit 1
+end
+
 def with_server(idle_connection_timeout = 5, &)
-  server = AMQProxy::Server.new("127.0.0.1", 5672, false)
+  server = AMQProxy::Server.new(UPSTREAM_URL)
   tcp_server = TCPServer.new("127.0.0.1", 0)
   amqp_url = "amqp://#{tcp_server.local_address}"
   spawn { server.listen(tcp_server) }
@@ -29,9 +37,13 @@ def with_http_server(idle_connection_timeout = 5, &)
 end
 
 def verify_running_amqp!
-  TCPSocket.new("127.0.0.1", 5672, connect_timeout: 3.seconds).close
+  tls = UPSTREAM_URL.scheme == "amqps"
+  host = UPSTREAM_URL.host || "127.0.0.1"
+  port = UPSTREAM_URL.port || 5762
+  port = 5671 if tls && UPSTREAM_URL.port.nil?
+  TCPSocket.new(host, port, connect_timeout: 3.seconds).close
 rescue Socket::ConnectError
-  STDERR.puts "[ERROR] Specs require a running amqp server on 127.0.0.1:5672"
+  STDERR.puts "[ERROR] Specs require a running amqp server on #{host}:#{port}"
   exit 1
 end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -46,7 +46,7 @@ def verify_running_amqp!
   port = 5671 if tls && UPSTREAM_URL.port.nil?
   TCPSocket.new(host, port, connect_timeout: 3.seconds).close
 rescue Socket::ConnectError
-  STDERR.puts "[ERROR] Specs require a running amqp server on #{host}:#{port}"
+  STDERR.puts "[ERROR] Specs require a running rabbitmq server on #{host}:#{port}"
   exit 1
 end
 

--- a/src/amqproxy.cr
+++ b/src/amqproxy.cr
@@ -1,2 +1,2 @@
 require "./amqproxy/cli"
-AMQProxy::CLI.new.run
+AMQProxy::CLI.new.run(ARGV)

--- a/src/amqproxy/cli.cr
+++ b/src/amqproxy/cli.cr
@@ -59,10 +59,10 @@ class AMQProxy::CLI
       parser.on("-t IDLE_CONNECTION_TIMEOUT", "--idle-connection-timeout=SECONDS", "Maxiumum time in seconds an unused pooled connection stays open (default 5s)") do |v|
         @idle_connection_timeout = v.to_i
       end
-      parser.on("--term-timeout=SECONDS", "At TERM the server SECONDS seconds for clients to gracefully close their sockets after Close has been sent (default: infinite)") do |v|
+      parser.on("--term-timeout=SECONDS", "At TERM the server waits SECONDS seconds for clients to gracefully close their sockets after Close has been sent (default: infinite)") do |v|
         @term_timeout = v.to_i
       end
-      parser.on("--term-client-close-timeout=SECONDS", "At TERM the server SECONDS seconds for clients to send Close beforing sending Close to clients (default: 0s)") do |v|
+      parser.on("--term-client-close-timeout=SECONDS", "At TERM the server waits SECONDS seconds for clients to send Close beforing sending Close to clients (default: 0s)") do |v|
         @term_client_close_timeout = v.to_i
       end
       parser.on("-d", "--debug", "Verbose logging") { @log_level = ::Log::Severity::Debug }

--- a/src/amqproxy/cli.cr
+++ b/src/amqproxy/cli.cr
@@ -48,8 +48,8 @@ class AMQProxy::CLI
     abort ex.message
   end
 
-  def run
-    p = OptionParser.parse do |parser|
+  def run(argv)
+    p = OptionParser.parse(argv) do |parser|
       parser.banner = "Usage: amqproxy [options] [amqp upstream url]"
       parser.on("-l ADDRESS", "--listen=ADDRESS", "Address to listen on (default is localhost)") do |v|
         @listen_address = v
@@ -72,7 +72,7 @@ class AMQProxy::CLI
       parser.invalid_option { |arg| abort "Invalid argument: #{arg}" }
     end
 
-    @upstream ||= ARGV.shift?
+    @upstream ||= argv.shift?
     upstream_url = @upstream || abort p.to_s
 
     u = URI.parse upstream_url


### PR DESCRIPTION
This will add a second shutdown timeout to wait for clients to send Close before sending Close to the clients.

Fixes #170