### PR TITLE
Show stack when debugging client connection failure

### DIFF
--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -66,7 +66,7 @@ module AMQProxy
         c.read_loop(channel_pool)
       end
     rescue ex # only raise from constructor, when negotating
-      Log.debug { "Client connection failure (#{remote_address}) #{ex.inspect}" }
+      Log.debug(exception: ex) { "Client connection failure (#{remote_address}) #{ex.inspect}" }
     ensure
       socket.close rescue nil
     end


### PR DESCRIPTION
Without passing the exception to the logger then the call stack cannot be debugged.