### PR TITLE
Add health check which doesn't go upstream

### DIFF
--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -65,8 +65,10 @@ module AMQProxy
         channel_pool = @channel_pools[c.credentials]
         c.read_loop(channel_pool)
       end
+    rescue ex : AMQProxy::Client::HealthCheck
+      Log.trace { "Client health check (#{remote_address})" }
     rescue ex # only raise from constructor, when negotating
-      Log.debug { "Client connection failure (#{remote_address}) #{ex.inspect}" }
+      Log.debug(exception: ex) { "Client connection failure (#{remote_address})" }
     ensure
       socket.close rescue nil
     end


### PR DESCRIPTION
This addresses a problem we saw with having a TCP 'socket open' health check for amqproxy (e.g. in a k8s environment). If debug was enabled then we would see socket EOF errors, as amqproxy tries to read from the client.

This health check is specifically for amqproxy, and not testing the upstream connection (we could use an AMQP heartbeat frame for that).

* Client sends `AMQP9999` only.
* amqproxy returns `HEALTHOK` and closes the connection.