### PR TITLE
Change the build to use static libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /tmp
 COPY shard.yml shard.lock ./
 RUN shards install --production
 COPY src/ src/
-RUN shards build --production --release
+RUN shards build --production --release --static
 
 FROM alpine:latest
 RUN apk add --no-cache libssl3 pcre2 libevent libgcc \


### PR DESCRIPTION
Changes the build process to use static libraries. This does make the docker image bigger, but stops any library mismatches coming from using different `alpine:latest` images in chained docker images.

Fixes https://github.com/cloudamqp/amqproxy/issues/178
Fixes https://github.com/cloudamqp/amqproxy/issues/174