### PR TITLE
Rearrange code to make file hierarchy match code hierarchy

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -6,7 +6,7 @@ authors:
 
 targets:
   amqproxy:
-    main: src/amqproxy/cli.cr
+    main: src/amqproxy.cr
 
 dependencies:
   amq-protocol:

--- a/shard.yml
+++ b/shard.yml
@@ -6,7 +6,7 @@ authors:
 
 targets:
   amqproxy:
-    main: src/amqproxy.cr
+    main: src/amqproxy/cli.cr
 
 dependencies:
   amq-protocol:

--- a/src/amqproxy.cr
+++ b/src/amqproxy.cr
@@ -1,0 +1,2 @@
+require "./amqproxy/cli"
+AMQProxy::CLI.new.run

--- a/src/amqproxy/cli.cr
+++ b/src/amqproxy/cli.cr
@@ -1,5 +1,5 @@
-require "./amqproxy/version"
-require "./amqproxy/server"
+require "./version"
+require "./server"
 require "option_parser"
 require "uri"
 require "ini"

--- a/src/amqproxy/cli.cr
+++ b/src/amqproxy/cli.cr
@@ -134,5 +134,3 @@ class AMQProxy::CLI
     end
   end
 end
-
-AMQProxy::CLI.new.run


### PR DESCRIPTION
This will rearrange code to make file hierarchy match code hierarchy.

Should be merged, not squashed, to keep the history for `src/amqproxy/cli.cr`.