### PR TITLE
Compile static binary and copy to scratch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,12 @@ WORKDIR /tmp
 COPY shard.yml shard.lock ./
 RUN shards install --production
 COPY src/ src/
-RUN shards build --production --release
+RUN shards build --production --release --static
 
-FROM alpine:latest
-RUN apk add --no-cache libssl3 pcre2 libevent libgcc \
-    && addgroup --gid 1000 amqpproxy \
-    && adduser --no-create-home --disabled-password --uid 1000 amqpproxy -G amqpproxy
-COPY --from=builder /tmp/bin/amqproxy /usr/bin/amqproxy
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem
+COPY --from=builder /tmp/bin/amqproxy /
 USER 1000:1000
 EXPOSE 5673
 ENV GC_UNMAP_THRESHOLD=1
-ENTRYPOINT ["/usr/bin/amqproxy", "--listen=0.0.0.0"]
+ENTRYPOINT ["/amqproxy", "--listen=0.0.0.0"]


### PR DESCRIPTION
Fixes problems with library version incompabilites between build and destination image when alpine is used.

Superseeds #180 