### PR TITLE
HTTP Health check and metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem
 COPY --from=builder /tmp/bin/amqproxy /
 USER 1000:1000
-EXPOSE 5673
+EXPOSE 5673 15673
 ENV GC_UNMAP_THRESHOLD=1
 ENTRYPOINT ["/amqproxy", "--listen=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ In our benchmarks publishing one message per connection to a server (using TLS) 
 
 As of version 2.0.0 connections to the server can be shared by multiple client connections. When a client opens a channel it will get a channel on a shared upstream connection, the proxy will remap the channel numbers between the two. Many client connections can therefor share a single upstream connection. The benefit is that way fewer connections are needed to the upstream server. For instance, establihsing 10.000 connections after a server reboot might normally take several minutes, but with this proxy it can happen in seconds.
 
+A health check for amqproxy is available over http on http://listen_address:http_port/healthz and will return 200 when amqproxy is healthy.
+
+Some metrics are available over http on http://listen_address:http_port/metrics
+
 ## Installation
 
 ### Debian/Ubuntu

--- a/spec/amqproxy/http_server_spec.cr
+++ b/spec/amqproxy/http_server_spec.cr
@@ -35,5 +35,3 @@ describe AMQProxy::HTTPServer do
     end
   end
 end
-
-

--- a/spec/amqproxy/http_server_spec.cr
+++ b/spec/amqproxy/http_server_spec.cr
@@ -1,0 +1,39 @@
+require "../spec_helper"
+require "../../src/amqproxy/http_server"
+require "http/client"
+
+base_addr = "http://localhost:15673"
+
+describe AMQProxy::HTTPServer do
+  it "GET /healthz returns 200" do
+    with_http_server do |http, amqproxy|
+      response = HTTP::Client.get("#{base_addr}/healthz")
+      response.status_code.should eq 200
+    end
+  end
+
+  it "GET /metrics returns 200" do
+    with_http_server do |http, amqproxy|
+      response = HTTP::Client.get("#{base_addr}/metrics")
+      response.status_code.should eq 200
+    end
+  end
+
+  it "GET /metrics returns correct metrics" do
+    with_http_server do |http, amqproxy, proxy_url|
+      AMQP::Client.start(proxy_url) do |conn|
+        ch = conn.channel
+        response = HTTP::Client.get("#{base_addr}/metrics")
+        response.body.split("\n").each do |line|
+          if line.starts_with?("amqproxy_client_connections")
+            line.should eq "amqproxy_client_connections 1"
+          elsif line.starts_with?("amqproxy_upstream_connections")
+            line.should eq "amqproxy_upstream_connections 1"
+          end
+        end
+      end
+    end
+  end
+end
+
+

--- a/spec/amqproxy/http_server_spec.cr
+++ b/spec/amqproxy/http_server_spec.cr
@@ -6,23 +6,23 @@ base_addr = "http://localhost:15673"
 
 describe AMQProxy::HTTPServer do
   it "GET /healthz returns 200" do
-    with_http_server do |http, amqproxy|
+    with_http_server do
       response = HTTP::Client.get("#{base_addr}/healthz")
       response.status_code.should eq 200
     end
   end
 
   it "GET /metrics returns 200" do
-    with_http_server do |http, amqproxy|
+    with_http_server do
       response = HTTP::Client.get("#{base_addr}/metrics")
       response.status_code.should eq 200
     end
   end
 
   it "GET /metrics returns correct metrics" do
-    with_http_server do |http, amqproxy, proxy_url|
+    with_http_server do |_http, _amqproxy, proxy_url|
       AMQP::Client.start(proxy_url) do |conn|
-        ch = conn.channel
+        _ch = conn.channel
         response = HTTP::Client.get("#{base_addr}/metrics")
         response.body.split("\n").each do |line|
           if line.starts_with?("amqproxy_client_connections")

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -20,10 +20,10 @@ end
 def with_http_server(idle_connection_timeout = 5, &)
   with_server do |server, amqp_url|
     http_server = AMQProxy::HTTPServer.new(server, "127.0.0.1", 15673)
-    yield http_server, server, amqp_url
-  ensure
-    if h = http_server
-      h.close
+    begin
+      yield http_server, server, amqp_url
+    ensure
+      http_server.close
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -16,3 +16,14 @@ ensure
     s.stop_accepting_clients
   end
 end
+
+def with_http_server(idle_connection_timeout = 5, &)
+  with_server do |server, amqp_url|
+    http_server = AMQProxy::HTTPServer.new(server, "127.0.0.1", 15673)
+    yield http_server, server, amqp_url
+  ensure
+    if h = http_server
+      h.close
+    end
+  end
+end

--- a/src/amqproxy/cli.cr
+++ b/src/amqproxy/cli.cr
@@ -107,7 +107,7 @@ class AMQProxy::CLI
     Signal::INT.trap &shutdown
     Signal::TERM.trap &shutdown
 
-    AMQProxy::HTTPServer.new(server, @listen_address, @http_port.to_i)
+    HTTPServer.new(server, @listen_address, @http_port.to_i)
     server.listen(@listen_address, @listen_port.to_i)
 
     # wait until all client connections are closed

--- a/src/amqproxy/http_server.cr
+++ b/src/amqproxy/http_server.cr
@@ -15,7 +15,6 @@ module AMQProxy
         when "/metrics"
           metrics(context)
         when "/healthz"
-          context.response.status = ::HTTP::Status::OK
           context.response.content_type = "text/plain"
           context.response.print "OK"
         else

--- a/src/amqproxy/http_server.cr
+++ b/src/amqproxy/http_server.cr
@@ -1,9 +1,4 @@
-require "socket"
 require "log"
-require "amq-protocol"
-require "./channel_pool"
-require "./client"
-require "./upstream"
 require "./prometheus_writer"
 require "http/server"
 

--- a/src/amqproxy/http_server.cr
+++ b/src/amqproxy/http_server.cr
@@ -1,0 +1,63 @@
+require "socket"
+require "log"
+require "amq-protocol"
+require "./channel_pool"
+require "./client"
+require "./upstream"
+require "./prometheus_writer"
+require "http/server"
+
+module AMQProxy
+  class HTTPServer
+    Log = ::Log.for(self)
+
+    def initialize(amqproxy : Server, address : String, port : Int32)
+      @amqproxy = amqproxy
+      @address = address
+      @port = port
+      @http = HTTP::Server.new do |context|
+        case context.request.resource
+        when "/metrics"
+          metrics(context)
+        when "/healthz"
+          context.response.status = ::HTTP::Status::OK
+          context.response.content_type = "text/plain"
+          context.response.print "OK"
+        else
+          context.response.status = ::HTTP::Status::NOT_FOUND
+        end
+      end
+      bind_tcp
+      spawn @http.listen, name: "HTTP_Server"
+      Log.info { "HTTP server listening on #{@address}:#{@port}" }
+    end
+
+    def bind_tcp
+      addr = @http.bind_tcp @address, @port
+      Log.info { "Bound to #{addr}" }
+    end
+
+    def metrics(context)
+      writer = PrometheusWriter.new(context.response, "amqproxy")
+
+      writer.write({name:   "identity_info",
+                    type:   "gauge",
+                    value:  1,
+                    help:   "System information",
+                    labels: {
+                      "#{writer.prefix}_version"  => AMQProxy::VERSION,
+                      "#{writer.prefix}_hostname" => System.hostname,
+                    }})
+      writer.write({name:  "client_connections",
+                    value: @amqproxy.client_connections,
+                    type:  "counter",
+                    help:  "Number of client connections"})
+      writer.write({name:  "upstream_connections",
+                    value: @amqproxy.upstream_connections,
+                    type:  "counter",
+                    help:  "Number of upstream connections"})
+
+      context.response.status = ::HTTP::Status::OK
+    end
+  end
+end

--- a/src/amqproxy/http_server.cr
+++ b/src/amqproxy/http_server.cr
@@ -28,7 +28,7 @@ module AMQProxy
         end
       end
       bind_tcp
-      spawn @http.listen, name: "HTTP_Server"
+      spawn @http.listen, name: "HTTP Server"
       Log.info { "HTTP server listening on #{@address}:#{@port}" }
     end
 
@@ -39,7 +39,6 @@ module AMQProxy
 
     def metrics(context)
       writer = PrometheusWriter.new(context.response, "amqproxy")
-
       writer.write({name:   "identity_info",
                     type:   "gauge",
                     value:  1,
@@ -50,11 +49,11 @@ module AMQProxy
                     }})
       writer.write({name:  "client_connections",
                     value: @amqproxy.client_connections,
-                    type:  "counter",
+                    type:  "gauge",
                     help:  "Number of client connections"})
       writer.write({name:  "upstream_connections",
                     value: @amqproxy.upstream_connections,
-                    type:  "counter",
+                    type:  "gauge",
                     help:  "Number of upstream connections"})
 
       context.response.status = ::HTTP::Status::OK

--- a/src/amqproxy/http_server.cr
+++ b/src/amqproxy/http_server.cr
@@ -53,5 +53,9 @@ module AMQProxy
 
       context.response.status = ::HTTP::Status::OK
     end
+
+    def close
+      @http.try &.close
+    end
   end
 end

--- a/src/amqproxy/http_server.cr
+++ b/src/amqproxy/http_server.cr
@@ -18,7 +18,7 @@ module AMQProxy
           context.response.content_type = "text/plain"
           context.response.print "OK"
         else
-          context.response.status = ::HTTP::Status::NOT_FOUND
+          context.response.respond_with_status(::HTTP::Status::NOT_FOUND)
         end
       end
       bind_tcp

--- a/src/amqproxy/prometheus_writer.cr
+++ b/src/amqproxy/prometheus_writer.cr
@@ -1,0 +1,47 @@
+class PrometheusWriter
+  alias MetricValue = UInt16 | Int32 | UInt32 | UInt64 | Int64 | Float64
+  alias MetricLabels = Hash(String, String) |
+                       NamedTuple(name: String) |
+                       NamedTuple(channel: String) |
+                       NamedTuple(id: String) |
+                       NamedTuple(queue: String, vhost: String)
+  alias Metric = NamedTuple(name: String, value: MetricValue) |
+                 NamedTuple(name: String, value: MetricValue, labels: MetricLabels) |
+                 NamedTuple(name: String, value: MetricValue, help: String) |
+                 NamedTuple(name: String, value: MetricValue, type: String, help: String) |
+                 NamedTuple(name: String, value: MetricValue, help: String, labels: MetricLabels) |
+                 NamedTuple(name: String, value: MetricValue, type: String, help: String, labels: MetricLabels)
+
+  getter prefix
+
+  def initialize(@io : IO, @prefix : String)
+  end
+
+  private def write_labels(io, labels)
+    first = true
+    io << "{"
+    labels.each do |k, v|
+      io << ", " unless first
+      io << k << "=\"" << v << "\""
+      first = false
+    end
+    io << "}"
+  end
+
+  def write(m : Metric)
+    return if m[:value].nil?
+    io = @io
+    name = "#{@prefix}_#{m[:name]}"
+    if t = m[:type]?
+      io << "# TYPE " << name << " " << t << "\n"
+    end
+    if h = m[:help]?
+      io << "# HELP " << name << " " << h << "\n"
+    end
+    io << name
+    if l = m[:labels]?
+      write_labels(io, l)
+    end
+    io << " " << m[:value] << "\n"
+  end
+end


### PR DESCRIPTION
Adds a health check over http on http://listen_address:http_port/healthz that returns 200 OK when amqproxy is up and running. 
Supersedes #179 

Also adds some simple prometheus style metrics. Just `client_connections` and `upstream_connections` for now, but this can be extended in the future (maybe some throughput stats and server resource information?).