### PR TITLE
use `/amqproxy` entrypoint in integration test instead of `amqproxy`

### DIFF
--- a/test/integration-php/docker-compose.yml
+++ b/test/integration-php/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build: ../../
     expose:
       - "5673"
-    entrypoint: ["/amqproxy", "--debug", "--listen=0.0.0.0", "amqp://toxiproxy:7777"]
+    command: ["--debug", "amqp://toxiproxy:7777"]
     depends_on:
       toxiproxy:
         condition: service_started

--- a/test/integration-php/docker-compose.yml
+++ b/test/integration-php/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build: ../../
     expose:
       - "5673"
-    entrypoint: ["amqproxy", "--debug", "--listen=0.0.0.0", "amqp://toxiproxy:7777"]
+    entrypoint: ["/amqproxy", "--debug", "--listen=0.0.0.0", "amqp://toxiproxy:7777"]
     depends_on:
       toxiproxy:
         condition: service_started


### PR DESCRIPTION
Fixes the integration test after changing the Dockerfile to copy to `/amqproxy` instead of `/usr/bin/amqproxy` [changed here](https://github.com/cloudamqp/amqproxy/commit/72eed33327cfd6034d0f6e3b0a45ad76c759ebd5)


error https://github.com/cloudamqp/amqproxy/actions/runs/11293679174/job/31412827700?pr=184