### PR TITLE
Don't log when a client just opens and closed TCP connection

### DIFF
--- a/src/amqproxy/client.cr
+++ b/src/amqproxy/client.cr
@@ -260,8 +260,6 @@ module AMQProxy
       socket.flush
 
       {tune_ok, Credentials.new(user, password, vhost)}
-    rescue ex
-      raise NegotiationError.new "Client negotiation failed", ex
     end
 
     ServerProperties = AMQ::Protocol::Table.new({
@@ -285,7 +283,5 @@ module AMQProxy
     class ReadError < Error; end
 
     class WriteError < Error; end
-
-    class NegotiationError < Error; end
   end
 end

--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -68,8 +68,10 @@ module AMQProxy
         channel_pool = @channel_pools[c.credentials]
         c.read_loop(channel_pool)
       end
+    rescue IO::EOFError
+      # Client closed connection before/while negotiating
     rescue ex # only raise from constructor, when negotating
-      Log.debug(exception: ex) { "Client connection failure (#{remote_address}) #{ex.inspect}" }
+      Log.debug(exception: ex) { "Client negotiation failure (#{remote_address}) #{ex.inspect}" }
     ensure
       socket.close rescue nil
     end


### PR DESCRIPTION
Rudimentary health checks, or port scanner, or whatever can open a TCP connection and then immediately close it without sending anything. This change suppresses debug logging for such connections.

Fixes #179