### PR TITLE
Set upstream connection_name to hostname

### DIFF
--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -232,7 +232,7 @@ module AMQProxy
     end
 
     ClientProperties = AMQ::Protocol::Table.new({
-      connection_name: "AMQProxy #{VERSION}",
+      connection_name: System.hostname,
       product:         "AMQProxy",
       version:         VERSION,
       capabilities:    {


### PR DESCRIPTION
Kubernetes exposes the podname via the `gethostname` glibc call. This will show the podname as the easy to read identifier for the connection.

Fixes #187

Could expose it as a config variable too, but I think this addresses the need and is much simplier, both as a patch and for the user to use.