### PR TITLE
Better naming for logs

### DIFF
--- a/src/amqproxy/channel_pool.cr
+++ b/src/amqproxy/channel_pool.cr
@@ -39,7 +39,7 @@ module AMQProxy
       upstream = Upstream.new(@host, @port, @tls_ctx, @credentials)
       Log.info { "Adding upstream connection" }
       @upstreams.unshift upstream
-      spawn do
+      spawn(name: "Upstream#read_loop") do
         begin
           upstream.read_loop
         ensure

--- a/src/amqproxy/client.cr
+++ b/src/amqproxy/client.cr
@@ -55,7 +55,7 @@ module AMQProxy
 
     # frames from enduser
     def read_loop(channel_pool, socket = @socket) # ameba:disable Metrics/CyclomaticComplexity
-      Log.context.set(remote_address: socket.remote_address.to_s)
+      Log.context.set(client: socket.remote_address.to_s)
       Log.debug { "Connected" }
       i = 0u64
       socket.read_timeout = (@heartbeat / 2).ceil.seconds if @heartbeat > 0

--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -61,7 +61,7 @@ module AMQProxy
 
     # Frames from upstream (to client)
     def read_loop(socket = @socket) # ameba:disable Metrics/CyclomaticComplexity
-      Log.context.set(remote_address: @remote_address)
+      Log.context.set(upstream: @remote_address)
       i = 0u64
       loop do
         case frame = AMQ::Protocol::Frame.from_io(socket, IO::ByteFormat::NetworkEndian)


### PR DESCRIPTION
- Make sure fibers has a name
- Use better keys in metadata to distinguish different socket fibers