### PR TITLE
Use conventional priority for setting configurable values

### DIFF
--- a/src/amqproxy/cli.cr
+++ b/src/amqproxy/cli.cr
@@ -16,7 +16,7 @@ class AMQProxy::CLI
   @idle_connection_timeout : Int32 = 5
   @term_timeout = -1
   @term_client_close_timeout = 0
-  @upstream = ""
+  @upstream = nil
   @server : AMQProxy::Server? = nil
 
   def parse_config(path) # ameba:disable Metrics/CyclomaticComplexity
@@ -94,7 +94,7 @@ class AMQProxy::CLI
       parser.invalid_option { |arg| abort "Invalid argument: #{arg}" }
     end
 
-    @upstream ||= argv.shift? || ""
+    @upstream ||= argv.shift?
     upstream_url = @upstream || abort p.to_s
 
     u = URI.parse upstream_url

--- a/src/amqproxy/cli.cr
+++ b/src/amqproxy/cli.cr
@@ -65,6 +65,7 @@ class AMQProxy::CLI
     # Parse config file first
     OptionParser.parse(argv) do |parser|
       parser.on("-c FILE", "--config=FILE", "Load config file") { |v| parse_config(v) }
+      parser.invalid_option { } # Invalid arguments are handled by the next OptionParser
     end
 
     apply_env_variables

--- a/src/amqproxy/cli.cr
+++ b/src/amqproxy/cli.cr
@@ -67,7 +67,6 @@ class AMQProxy::CLI
       parser.on("-c FILE", "--config=FILE", "Load config file") { |v| parse_config(v) }
     end
 
-    # Apply environment variables
     apply_env_variables
 
     # Parse CLI arguments

--- a/src/amqproxy/cli.cr
+++ b/src/amqproxy/cli.cr
@@ -16,7 +16,6 @@ class AMQProxy::CLI
   @idle_connection_timeout : Int32 = 5
   @term_timeout = -1
   @term_client_close_timeout = 0
-  @upstream = nil
   @server : AMQProxy::Server? = nil
 
   def parse_config(path) # ameba:disable Metrics/CyclomaticComplexity
@@ -53,7 +52,7 @@ class AMQProxy::CLI
     @listen_address = ENV["LISTEN_ADDRESS"]? || @listen_address
     @listen_port = ENV["LISTEN_PORT"]?.try &.to_i || @listen_port
     @http_port = ENV["HTTP_PORT"]?.try &.to_i || @http_port
-    @log_level = ::Log::Severity.parse(ENV["LOG_LEVEL"]) || @log_level
+    @log_level = ENV["LOG_LEVEL"]?.try { |level| ::Log::Severity.parse(level) } || @log_level
     @idle_connection_timeout = ENV["IDLE_CONNECTION_TIMEOUT"]?.try &.to_i || @idle_connection_timeout
     @term_timeout = ENV["TERM_TIMEOUT"]?.try &.to_i || @term_timeout
     @term_client_close_timeout = ENV["TERM_CLIENT_CLOSE_TIMEOUT"]?.try &.to_i || @term_client_close_timeout


### PR DESCRIPTION
Today, the config variables are set in the priority order 
1. CLI arguments
2. Config file
3. ENV variables

This pr changes so the config variables are set in a conventional priority order 
1. CLI arguments 
2. ENV variables
3. Config file 

WIP, 
Adresses questions in #192 