### PR TITLE
Multi-threading support

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.6.1
+    version: 1.6.4
 
   amq-protocol:
     git: https://github.com/cloudamqp/amq-protocol.cr.git
@@ -10,5 +10,5 @@ shards:
 
   amqp-client:
     git: https://github.com/cloudamqp/amqp-client.cr.git
-    version: 1.2.5
+    version: 1.3.0
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -31,6 +31,7 @@ end
 def with_http_server(idle_connection_timeout = 5, &)
   with_server do |server, amqp_url|
     http_server = AMQProxy::HTTPServer.new(server, "127.0.0.1", 15673)
+    spawn { http_server.listen }
     begin
       yield http_server, server, amqp_url
     ensure
@@ -45,6 +46,7 @@ def verify_running_amqp!
   port = UPSTREAM_URL.port || 5762
   port = 5671 if tls && UPSTREAM_URL.port.nil?
   TCPSocket.new(host, port, connect_timeout: 3.seconds).close
+  puts "AMQP running"
 rescue Socket::ConnectError
   STDERR.puts "[ERROR] Specs require a running rabbitmq server on #{host}:#{port}"
   exit 1

--- a/src/amqproxy.cr
+++ b/src/amqproxy.cr
@@ -1,2 +1,15 @@
 require "./amqproxy/cli"
+{% begin %}
+  {%
+    flags = [] of String
+    flags << "-Dpreview_mt" if flag?(:preview_mt)
+    flags << "-Dmt" if flag?(:mt)
+    flags << "-Dexecution_context" if flag?(:execution_context)
+    flags << "-Dtracing" if flag?(:tracing)
+    flags << "--release" if flag?(:release)
+    flags << "--static" if flag?(:static)
+    flags << "--debug" if flag?(:debug)
+  %}
+  puts "Built with #{Crystal::VERSION} #{Crystal::BUILD_COMMIT} {{flags.join(" ").id}}"
+{% end %}
 AMQProxy::CLI.new.run(ARGV)

--- a/src/amqproxy/cli.cr
+++ b/src/amqproxy/cli.cr
@@ -5,7 +5,6 @@ require "option_parser"
 require "uri"
 require "ini"
 require "log"
-require "wait_group"
 
 class AMQProxy::CLI
   Log = ::Log.for(self)

--- a/src/amqproxy/client.cr
+++ b/src/amqproxy/client.cr
@@ -65,7 +65,7 @@ module AMQProxy
       socket.read_timeout = (@heartbeat / 2).ceil.seconds if @heartbeat > 0
       loop do
         frame = AMQ::Protocol::Frame.from_io(socket, IO::ByteFormat::NetworkEndian)
-        Log.debug { "Received frame: #{frame}" }
+        Log.trace { "Received frame: #{frame}" }
         @last_heartbeat = Time.monotonic
         case frame
         when AMQ::Protocol::Frame::Heartbeat # noop
@@ -139,7 +139,7 @@ module AMQProxy
     # Send frame to client, channel id should already be remapped by the caller
     def write(frame : AMQ::Protocol::Frame)
       @lock.synchronize do
-        Log.debug { "Sending frame: #{frame}" }
+        Log.trace { "Sending frame: #{frame}" }
         case frame
         when AMQ::Protocol::Frame::BytesBody
           # Upstream might send large frames, split them to support lower client frame_max

--- a/src/amqproxy/http_server.cr
+++ b/src/amqproxy/http_server.cr
@@ -22,13 +22,16 @@ module AMQProxy
         end
       end
       bind_tcp
-      spawn @http.listen, name: "HTTP Server"
       Log.info { "HTTP server listening on #{@address}:#{@port}" }
     end
 
     def bind_tcp
       addr = @http.bind_tcp @address, @port
       Log.info { "Bound to #{addr}" }
+    end
+
+    def listen
+      @http.listen
     end
 
     def metrics(context)


### PR DESCRIPTION
This PR will make amqproxy thread-safe and ready to use with both `-Dpreview_mt` and upcoming [Execution Contexts](https://github.com/crystal-lang/rfcs/pull/2).

I haven't run into any deadlocks or segfaults, but if any locks is needed around `Client#channel_map` and/or `Upstream#channels` it's already prepared for by adding `Client#with_channel_map` and `Upstream#with_channels`.