### PR TITLE
Add manual trigger support for Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,12 @@ on:
       - shard.lock
       - Dockerfile
       - .github/workflows/docker.yml
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g., v1.0.0)'
+        required: true
+        type: string
 
 jobs:
   docker:
@@ -27,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Docker meta
         id: meta
@@ -38,6 +46,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to enable manual Docker image builds
- Allow selecting existing tags for rebuilding through GitHub Actions UI
- Maintain compatibility with existing push-based triggers

## Test plan
- [ ] Verify workflow can be manually triggered from GitHub Actions UI
- [ ] Test with an existing tag (e.g., latest version tag)
- [ ] Confirm original push-based triggers still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)