### PR TITLE
Close downstream connections when upstream connection closes.

### DIFF
--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -122,7 +122,7 @@ module AMQProxy
         end
 
         clients.each do |client|
-          Log.debug { "Closing client connection due to upstream failure. Client: #{client}" }
+          Log.debug { "Closing client connection due to upstream failure." }
           client.close_connection(code, reason)
         end
         @channels.clear

--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -114,13 +114,20 @@ module AMQProxy
     end
 
     private def close_all_client_channels(code = 500_u16, reason = "UPSTREAM_ERROR")
+      clients = Set(Client).new
       @channels_lock.synchronize do
         return if @channels.empty?
         Log.debug { "Upstream connection closed, closing #{@channels.size} client channels" }
         @channels.each_value do |downstream_channel|
-          downstream_channel.close(code, reason)
+          clients << downstream_channel.client
         end
         @channels.clear
+      end
+      
+      # Close all client connections that were using this upstream
+      clients.each do |client|
+        Log.debug { "Closing client connection due to upstream failure" }
+        client.close_connection(code, reason)
       end
     end
 

--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -117,12 +117,12 @@ module AMQProxy
       clients = Set(Client).new
       @channels_lock.synchronize do
         return if @channels.empty?
+        Log.debug { "Upstream connection closed, closing #{@channels.size} client connections" }
         @channels.each_value do |downstream_connection|
           clients << downstream_connection.client
         end
 
         clients.each do |client|
-          Log.debug { "Closing client connection due to upstream failure." }
           client.close_connection(code, reason)
         end
         @channels.clear


### PR DESCRIPTION
Currently when upstream connection closes we close the channels on the downstream connections, which is a change in how v1.0.0 used to work. This PR instead closes downstream connections when upstream closes, which makes it easier for clients to reconnect on closed connections. 