### PR TITLE
Adding support for TLS connections from client to amqproxy

### DIFF
--- a/src/amqproxy/connection_info.cr
+++ b/src/amqproxy/connection_info.cr
@@ -1,0 +1,46 @@
+require "socket"
+
+module AMQProxy
+  class ConnectionInfo
+    getter remote_address : IPAddress
+    getter local_address : IPAddress
+    property? ssl : Bool = false
+    property? ssl_verify : Bool = false
+    property ssl_version : String?
+    property ssl_cipher : String?
+    property ssl_key_alg : String?
+    property ssl_sig_alg : String?
+    property ssl_cn : String?
+
+    # Remote and local addresses from the server's perspective
+    def initialize(remote_address, local_address)
+      @remote_address = IPAddress.new(remote_address)
+      @local_address = IPAddress.new(local_address)
+    end
+
+    def self.local
+      src = Socket::IPAddress.new("127.0.0.1", 0)
+      dst = Socket::IPAddress.new("127.0.0.1", 0)
+      new(src, dst)
+    end
+
+    # Suspecting memory problem with Socket::IPAddress in Crystal 1.15.0
+    struct IPAddress
+      getter address : String
+      getter port : UInt16
+
+      def initialize(ip_address : Socket::IPAddress)
+        @address = ip_address.address
+        @port = ip_address.port.to_u16!
+      end
+
+      def to_s(io)
+        io << @address << ':' << @port
+      end
+
+      def loopback?
+        @address == "::1" || @address.starts_with? "127."
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull requests supports TLS connections from clients to amqproxy.  I cannot think of a compelling reason to support both TLS and non-TLS connections simulteneously, so either TLS or non-TLS can be utilized.  I think that should keep the management of the connection pools simpler.