### PR TITLE
Preventing duplicate channel.close frames that lead to channel errors

### DIFF
--- a/src/amqproxy/upstream.cr
+++ b/src/amqproxy/upstream.cr
@@ -57,7 +57,12 @@ module AMQProxy
     end
 
     def close_channel(id, code, reason)
-      send AMQ::Protocol::Frame::Channel::Close.new(id, code, reason, 0_u16, 0_u16)
+      # Only send Channel::Close if the channel is still open (exists in our map)
+      @channels_lock.synchronize do
+        if @channels.has_key?(id)
+          send AMQ::Protocol::Frame::Channel::Close.new(id, code, reason, 0_u16, 0_u16)
+        end
+      end
     end
 
     def channels


### PR DESCRIPTION
Under some conditions (like a client crashing), 2 separate channel.close frames can be sent by amqproxy to the upstream.  This is catastrophic because the upstream will close the connection, which closes all client connections through the proxy.  This pull tries to ensure that duplicate channel.close frames are never sent.