### PR TITLE
Build packages for Debian 13

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -48,6 +48,7 @@ jobs:
           - ubuntu-noble    # Ubuntu 24.04
           - ubuntu-jammy    # Ubuntu 22.04
           - ubuntu-focal    # Ubuntu 20.04
+          - debian-trixie   # Debian 13
           - debian-bookworm # Debian 12
           - debian-bullseye # Debian 11
       fail-fast: false


### PR DESCRIPTION
Debian 13 was released August 9th 2025:
https://www.debian.org/releases/trixie/