### PR TITLE
Move static package build to separate workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 name: Create Release
 
 jobs:
-  build:
+  release:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
@@ -16,25 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build static tar package
-        uses: docker/build-push-action@v6
-        with:
-          file: tar.Dockerfile
-          platforms: linux/amd64,linux/arm64
-          outputs: .
-          cache-from: type=gha,scope=release
-          cache-to: type=gha,mode=max,scope=release
-
-      - name: List files
-        run: ls -Rl
-
       - name: Create Release
-        run: gh release create "${{ github.ref }}" ./**/*.tar.gz --notes "$(./build/release_notes)"
+        run: gh release create "${{ github.ref }}" --notes "$(./build/release_notes)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/static-release.yml
+++ b/.github/workflows/static-release.yml
@@ -1,0 +1,37 @@
+name: Upload static packages to release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  static:
+    name: Build and upload static packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build static tar package
+        uses: docker/build-push-action@v6
+        with:
+          file: tar.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          outputs: builds
+          cache-from: type=gha,scope=static-release
+          cache-to: type=gha,mode=max,scope=static-release
+
+      - name: Upload to release
+        run: gh release upload "${{ github.event.release.tag_name }}" builds/**/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Split the release workflow into two separate workflows
- `release.yml` now only creates the GitHub release with notes
- New `static-release.yml` triggers on release publish, builds static tar packages (linux/amd64, linux/arm64), and uploads them to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)