### PR TITLE
Fix default AMQP port typo

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -46,7 +46,7 @@ end
 def verify_running_amqp!
   tls = UPSTREAM_URL.scheme == "amqps"
   host = UPSTREAM_URL.host || "127.0.0.1"
-  port = UPSTREAM_URL.port || 5762
+  port = UPSTREAM_URL.port || 5672
   port = 5671 if tls && UPSTREAM_URL.port.nil?
   TCPSocket.new(host, port, connect_timeout: 3.seconds).close
 rescue Socket::ConnectError

--- a/src/amqproxy/server.cr
+++ b/src/amqproxy/server.cr
@@ -15,7 +15,7 @@ module AMQProxy
     def self.new(url : URI)
       tls = url.scheme == "amqps"
       host = url.host || "127.0.0.1"
-      port = url.port || 5762
+      port = url.port || 5672
       port = 5671 if tls && url.port.nil?
       idle_connection_timeout = url.query_params.fetch("idle_connection_timeout", 5).to_i
       new(host, port, tls, idle_connection_timeout)


### PR DESCRIPTION
Fix typo in default port fallback that caused connection failures when AMQP_URL omits the port.

Fixes #242 